### PR TITLE
MySQL/linux case sensitive compatibility

### DIFF
--- a/odmtools/odmservices/series_service.py
+++ b/odmtools/odmservices/series_service.py
@@ -522,7 +522,7 @@ class SeriesService():
         :param values: pandas dataframe
         :return:
         """
-        values.to_sql(name="datavalues", if_exists='append', con=self._session_factory.engine, index=False)
+        values.to_sql(name="DataValues", if_exists='append', con=self._session_factory.engine, index=False)  ## FAP 160127
 
 
     def create_new_series(self, data_values, site_id, variable_id, method_id, source_id, qcl_id):


### PR DESCRIPTION
Hi all,

I use "LittleBear_ODM_1.1.1_MySQL.sql" example database with linux 64bit based platform. After executing this sql code, database was created and I could explore it (through phphmyadmin). Launching ODMTools, I give database coordinates and application tries to connect, unsuccessfully. Issue was about table names which were all lower case whereas ODMTools expected upper case like "DataValues" instead of "datavalues". So I changed all table names (except for "seriescatalog" which was still expected lower case).

Then ODMTools opened successfully and I could explore all the data series. I then tried to make some edits (see also "Lasso widget disabled " issue).

After saving edits, ODM could retrieve new variable (with Quality control level set to 1) in table "seriescatalog" but no data were shown on graph. In fact, these data had been written in a new table called "datavalues". This table has been created by ODMTools at the time I saved my edits.

I could fix this issue by changing line 525 in file in odmtools/odmservices/series_service.py to :
```python
values.to_sql(name="DataValues", if_exists='append', con=self._session_factory.engine, index=False)  ## FAP 160127
```
instead of :
```python
values.to_sql(name="datavalues", if_exists='append', con=self._session_factory.engine, index=False)
```
Please find attached the file I modified in Pull request "MySQL/linux case sensitive compatibility"
Best regards,
Florent