### PR TITLE
Table Selection Should Initiate Radio Button on Method Selection for Save

### DIFF
--- a/odmtools/gui/mnuRibbon.py
+++ b/odmtools/gui/mnuRibbon.py
@@ -15,7 +15,7 @@ from frmFlagValues import frmFlagValues
 from odmtools.controller.frmLinearDrift import frmLinearDrift
 from odmtools.controller.frmAbout import frmAbout
 import wizSave
-from odmtools.common import *
+from odmtools.common.icons import *
 import pandas as pd
 
 

--- a/odmtools/gui/pageMethod.py
+++ b/odmtools/gui/pageMethod.py
@@ -63,7 +63,7 @@ class pnlMethod(wx.Panel):
         self.lstMethods.SetColumnWidth(0, 200)
         self.lstMethods.SetColumnWidth(1, 153)
         self.lstMethods.SetColumnWidth(2,0)
-        self.lstMethods.Enable(False)
+        # self.lstMethods.Enable(False)
 
 
 
@@ -77,7 +77,7 @@ class pnlMethod(wx.Panel):
         self.rbSelect.SetValue(True)
 
     def OnRbGenerateRadiobutton(self, event):
-        self.lstMethods.Enable(False)
+        # self.lstMethods.Enable(False)
         self.txtMethodDescrip.Enable(False)
 
         event.Skip()

--- a/odmtools/gui/pageMethod.py
+++ b/odmtools/gui/pageMethod.py
@@ -54,6 +54,7 @@ class pnlMethod(wx.Panel):
         self.lstMethods = wx.ListCtrl(id=wxID_PNLMETHODSLISTCTRL1,
               name='lstMethods', parent=self, pos=wx.Point(16, 48),
               size=wx.Size(392, 152), style=wx.LC_REPORT|wx.LC_SINGLE_SEL)
+        self.lstMethods.Bind(wx.EVT_SET_FOCUS, self.OnLstMethodSetFocus)
 
 
         self.lstMethods.InsertColumn(0, 'Description')
@@ -71,6 +72,9 @@ class pnlMethod(wx.Panel):
         self.series_service = sm.get_series_service()
         self.prev_val = method
         self._init_ctrls(parent)
+
+    def OnLstMethodSetFocus(self, event):
+        self.rbSelect.SetValue(True)
 
     def OnRbGenerateRadiobutton(self, event):
         self.lstMethods.Enable(False)


### PR DESCRIPTION
When selecting a method in the save dialog, if a user selects a method from the table of existing methods, this should cause the associated radio button to be selected.

![image](https://cloud.githubusercontent.com/assets/5023186/15341779/0d88b076-1c4e-11e6-9f59-61239d1c230e.png)
